### PR TITLE
feat: python support for poll (request jobs) and accept

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ proto: protoc ## Generates the API code and documentation
 
 .PHONY: python
 python: python ## Generate python proto files in python
-	pip freeze | grep grpcio-tools
+	# pip freeze | grep grpcio-tools
 	mkdir -p python/v1/rainbow/protos
 	cd python/v1/rainbow/protos
 	python -m grpc_tools.protoc -I./api/v1 --python_out=./python/v1/rainbow/protos --pyi_out=./python/v1/rainbow/protos --grpc_python_out=./python/v1/rainbow/protos ./api/v1/rainbow.proto
@@ -35,12 +35,12 @@ version: ## Prints the current version
 	@echo $(VERSION)
 
 .PHONY: tidy
-tidy: ## Updates the go modules and vendors all dependancies 
+tidy: ## Updates the go modules and vendors all dependencies
 	go mod tidy
 	go mod vendor
 
 .PHONY: upgrade
-upgrade: ## Upgrades all dependancies 
+upgrade: ## Upgrades all dependencies
 	go get -d -u ./...
 	go mod tidy
 	go mod vendor

--- a/README.md
+++ b/README.md
@@ -203,6 +203,22 @@ What this does is randomly select from the set you receive, and send back a resp
 The logic you would expect is there - that you can't accept greater than the number available.
 You could try asking for a high level of max jobs again, and see that there is one fewer than before. It was deleted from the database.
 
+## Python
+
+To build Python GRPC, ensure you have the grpc-tools installed:
+
+```bash
+pip install grpcio-tools
+```
+
+Then:
+
+```bash
+make python
+```
+
+and cd into [python/v1](python/v1) and follow the README instructions there.
+
 
 ## Container Images
 
@@ -210,11 +226,9 @@ You could try asking for a high level of max jobs again, and see that there is o
 
 ## TODO
 
-- endpoint to summarize jobs? Or update the request jobs to return a summary?
-- request jobs should accept way to filter or specify criteria for request
-- receiving endpoint to accept (meaning just deleting from the database)
+- (advanced) request jobs should accept way to filter or specify criteria for request
 
-Next steps: Python bindings so we can run the client in a flux instance and:
+Next steps: Containers and example (kind?) to run in a flux instance and:
 
 - Run in poll, at some increment
 - "Do you have jobs for me?"

--- a/python/v1/examples/flux/poll-jobs.py
+++ b/python/v1/examples/flux/poll-jobs.py
@@ -1,0 +1,85 @@
+from __future__ import print_function
+
+import logging
+
+import argparse
+import grpc
+import random
+from rainbow.protos import rainbow_pb2
+from rainbow.protos import rainbow_pb2_grpc
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="🌈️ Rainbow scheduler poll (request jobs) and accept"
+    )
+    parser.add_argument("--cluster", help="cluster name to register", default="keebler")
+    parser.add_argument(
+        "--host", help="host of rainbow cluster", default="localhost:50051"
+    )
+    parser.add_argument(
+        "--max-jobs", help="Maximum jobs to request (unset defaults to all)", type=int
+    )
+    parser.add_argument(
+        "--secret", help="Cluster secret to access job queue", required=True
+    )
+    parser.add_argument(
+        "--nodes", help="Nodes for job (defaults to 1)", default=1, type=int
+    )
+    parser.add_argument("--accept", help="Number of jobs to accept", type=int)
+    return parser
+
+
+def main():
+
+    parser = get_parser()
+    args, _ = parser.parse_known_args()
+
+    # These are submit variables. A more substantial submit script would have argparse, etc.
+    pollRequest = rainbow_pb2.RequestJobsRequest(
+        secret=args.secret, maxJobs=args.max_jobs, cluster=args.cluster
+    )
+
+    # NOTE(gRPC Python Team): .close() is possible on a channel and should be
+    # used in circumstances in which the with statement does not fit the needs
+    # of the code.
+    with grpc.insecure_channel(args.host) as channel:
+        stub = rainbow_pb2_grpc.RainbowSchedulerStub(channel)
+        response = stub.RequestJobs(pollRequest)
+        if response.status != 1:
+            print("Issue with requesting jobs:")
+            print(response)
+            return
+
+        # Unwrap ourselves to prettier print
+        print("Status: REQUEST_JOBS_SUCCESS")
+        print(f"Received {len(response.jobs)} jobs for inspection!")
+        for _, job in response.jobs.items():
+            # Note this can be json loaded, it's a json string
+            print(job)
+
+        # Cut out early if not accepting
+        if not args.accept or args.accept < 0:
+            return
+
+        # We would normally save metadata to submit to flux, but just faux accept
+        # for now (meaning we just need the job ids)
+        jobs = list(response.jobs)
+        random.shuffle(jobs)
+
+        # We can only accept up to the max that we have
+        if args.accept > len(jobs):
+            args.accept = len(jobs)
+
+        accepted = jobs[: args.accept]
+        print(f"Accepting {args.accept} jobs...")
+        print(accepted)
+        acceptRequest = rainbow_pb2.AcceptJobsRequest(
+            secret=args.secret, jobids=accepted, cluster=args.cluster
+        )
+        response = stub.AcceptJobs(acceptRequest)
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+    main()

--- a/python/v1/examples/flux/register.py
+++ b/python/v1/examples/flux/register.py
@@ -2,35 +2,52 @@ from __future__ import print_function
 
 import logging
 
-import sys
+import argparse
 import grpc
-from rainbow.protos import api_pb2
-from rainbow.protos import api_pb2_grpc
+from rainbow.protos import rainbow_pb2
+from rainbow.protos import rainbow_pb2_grpc
 
 
-def main(cluster):
+def get_parser():
+    parser = argparse.ArgumentParser(description="🌈️ Rainbow scheduler register")
+    parser.add_argument("--cluster", help="cluster name to register", default="keebler")
+    parser.add_argument(
+        "--host", help="host of rainbow cluster", default="localhost:50051"
+    )
+    parser.add_argument(
+        "--secret",
+        help="Rainbow cluster registration secret",
+        default="chocolate-cookies",
+    )
+    return parser
+
+
+def main():
+
+    parser = get_parser()
+    args, _ = parser.parse_known_args()
 
     # These are the variables for our cluster - name for now
-    registerRequest = api_pb2.RegisterRequest(name=cluster, secret="chocolate-cookies")
+    registerRequest = rainbow_pb2.RegisterRequest(name=args.cluster, secret=args.secret)
 
     # NOTE(gRPC Python Team): .close() is possible on a channel and should be
     # used in circumstances in which the with statement does not fit the needs
     # of the code.
-    with grpc.insecure_channel("localhost:50051") as channel:
-        stub = api_pb2_grpc.RainbowSchedulerStub(channel)
+    with grpc.insecure_channel(args.host) as channel:
+        stub = rainbow_pb2_grpc.RainbowSchedulerStub(channel)
         response = stub.Register(registerRequest)
         print(response)
-        if response.status == api_pb2.RegisterResponse.ResultType.REGISTER_EXISTS:
-            print(f"The cluster {cluster} alreadey exists.")
+        if response.status == rainbow_pb2.RegisterResponse.ResultType.REGISTER_EXISTS:
+            print(f"The cluster {args.cluster} already exists.")
         else:
             print(
-                f"The token you will need to submit jobs to this cluster is {response.token}",
+                f"🤫️ The token you will need to submit jobs to this cluster is {response.token}",
+            )
+            print(
+                f"🔐️ The secret you will need to accept jobs is {response.secret}",
             )
 
 
 if __name__ == "__main__":
     logging.basicConfig()
-    cluster = "keebler"
-    if len(sys.argv) > 1:
-        cluster = sys.argv[1]
-    main(cluster)
+    main()

--- a/python/v1/examples/flux/submit-job.py
+++ b/python/v1/examples/flux/submit-job.py
@@ -2,17 +2,42 @@ from __future__ import print_function
 
 import logging
 
-import sys
+import argparse
 import grpc
-from rainbow.protos import api_pb2
-from rainbow.protos import api_pb2_grpc
+import sys
+from rainbow.protos import rainbow_pb2
+from rainbow.protos import rainbow_pb2_grpc
 
 
-def main(token):
+def get_parser():
+    parser = argparse.ArgumentParser(description="🌈️ Rainbow scheduler submit")
+    parser.add_argument("--cluster", help="cluster name to register", default="keebler")
+    parser.add_argument(
+        "--host", help="host of rainbow cluster", default="localhost:50051"
+    )
+    parser.add_argument(
+        "--token", help="Cluster token for permission to submit jobs", required=True
+    )
+    parser.add_argument(
+        "--nodes", help="Nodes for job (defaults to 1)", default=1, type=int
+    )
+    parser.add_argument("command", help="Command to submit", nargs="+")
+    return parser
+
+
+def main():
+
+    parser = get_parser()
+    args, _ = parser.parse_known_args()
+
+    if not args.command:
+        sys.exit("A command (positional arguments) is required")
+    command = " ".join(args.command)
+    print(f"⭐️ Submitting job: {command}")
 
     # These are submit variables. A more substantial submit script would have argparse, etc.
-    submitRequest = api_pb2.SubmitJobRequest(
-        token=token, nodes=1, cluster="keebler", command="hostname"
+    submitRequest = rainbow_pb2.SubmitJobRequest(
+        token=args.token, nodes=args.nodes, cluster=args.cluster, command=command
     )
 
     # These are the variables currently allowed:
@@ -27,16 +52,12 @@ def main(token):
     # NOTE(gRPC Python Team): .close() is possible on a channel and should be
     # used in circumstances in which the with statement does not fit the needs
     # of the code.
-    with grpc.insecure_channel("localhost:50051") as channel:
-        stub = api_pb2_grpc.RainbowSchedulerStub(channel)
+    with grpc.insecure_channel(args.host) as channel:
+        stub = rainbow_pb2_grpc.RainbowSchedulerStub(channel)
         response = stub.SubmitJob(submitRequest)
         print(response)
 
 
 if __name__ == "__main__":
     logging.basicConfig()
-    if len(sys.argv) < 2:
-        sys.exit(
-            "Please include the secret token you received when registering your cluster"
-        )
-    main(sys.argv[1])
+    main()

--- a/python/v1/rainbow/protos/rainbow_pb2.py
+++ b/python/v1/rainbow/protos/rainbow_pb2.py
@@ -16,7 +16,7 @@ from google.protobuf import any_pb2 as google_dot_protobuf_dot_any__pb2
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rrainbow.proto\x12\x1e\x63onvergedcomputing.org.grpc.v1\x1a\x19google/protobuf/any.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb3\x01\n\x07\x43ontent\x12\n\n\x02id\x18\x01 \x01(\t\x12\"\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x14.google.protobuf.Any\x12G\n\x08metadata\x18\x03 \x03(\x0b\x32\x35.convergedcomputing.org.grpc.v1.Content.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"m\n\x07Request\x12\x38\n\x07\x63ontent\x18\x01 \x01(\x0b\x32\'.convergedcomputing.org.grpc.v1.Content\x12(\n\x04sent\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"Y\n\x0fRegisterRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06secret\x18\x02 \x01(\t\x12(\n\x04sent\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\x99\x01\n\x10SubmitJobRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x63luster\x18\x02 \x01(\t\x12\r\n\x05token\x18\x03 \x01(\t\x12\r\n\x05nodes\x18\x04 \x01(\x05\x12\r\n\x05tasks\x18\x05 \x01(\x05\x12\x0f\n\x07\x63ommand\x18\x06 \x01(\t\x12(\n\x04sent\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"p\n\x12RequestJobsRequest\x12\x0f\n\x07\x63luster\x18\x01 \x01(\t\x12\x0e\n\x06secret\x18\x02 \x01(\t\x12\x0f\n\x07maxJobs\x18\x03 \x01(\x05\x12(\n\x04sent\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\xc8\x01\n\x08Response\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\x15\n\rmessage_count\x18\x02 \x01(\x03\x12\x1a\n\x12messages_processed\x18\x03 \x01(\x03\x12\x1a\n\x12processing_details\x18\x04 \x01(\t\"Y\n\nResultType\x12\x1b\n\x17RESULT_TYPE_UNSPECIFIED\x10\x00\x12\x17\n\x13RESULT_TYPE_SUCCESS\x10\x01\x12\x15\n\x11RESULT_TYPE_ERROR\x10\x02\"\x8e\x02\n\x10RegisterResponse\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\r\n\x05token\x18\x02 \x01(\t\x12\x0e\n\x06secret\x18\x03 \x01(\t\x12K\n\x06status\x18\x04 \x01(\x0e\x32;.convergedcomputing.org.grpc.v1.RegisterResponse.ResultType\"z\n\nResultType\x12\x18\n\x14REGISTER_UNSPECIFIED\x10\x00\x12\x14\n\x10REGISTER_SUCCESS\x10\x01\x12\x12\n\x0eREGISTER_ERROR\x10\x02\x12\x13\n\x0fREGISTER_DENIED\x10\x03\x12\x13\n\x0fREGISTER_EXISTS\x10\x04\"\xe3\x01\n\x11SubmitJobResponse\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\r\n\x05jobid\x18\x02 \x01(\x05\x12L\n\x06status\x18\x03 \x01(\x0e\x32<.convergedcomputing.org.grpc.v1.SubmitJobResponse.ResultType\"]\n\nResultType\x12\x16\n\x12SUBMIT_UNSPECIFIED\x10\x00\x12\x12\n\x0eSUBMIT_SUCCESS\x10\x01\x12\x10\n\x0cSUBMIT_ERROR\x10\x02\x12\x11\n\rSUBMIT_DENIED\x10\x03\"\xe8\x02\n\x13RequestJobsResponse\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12K\n\x04jobs\x18\x02 \x03(\x0b\x32=.convergedcomputing.org.grpc.v1.RequestJobsResponse.JobsEntry\x12N\n\x06status\x18\x03 \x01(\x0e\x32>.convergedcomputing.org.grpc.v1.RequestJobsResponse.ResultType\x1a+\n\tJobsEntry\x12\x0b\n\x03key\x18\x01 \x01(\x05\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"s\n\nResultType\x12\x1a\n\x16REQUEST_JOBS_NORESULTS\x10\x00\x12\x18\n\x14REQUEST_JOBS_SUCCESS\x10\x01\x12\x16\n\x12REQUEST_JOBS_ERROR\x10\x02\x12\x17\n\x13REQUEST_JOBS_DENIED\x10\x03\x32\xa9\x04\n\x10RainbowScheduler\x12m\n\x08Register\x12/.convergedcomputing.org.grpc.v1.RegisterRequest\x1a\x30.convergedcomputing.org.grpc.v1.RegisterResponse\x12p\n\tSubmitJob\x12\x30.convergedcomputing.org.grpc.v1.SubmitJobRequest\x1a\x31.convergedcomputing.org.grpc.v1.SubmitJobResponse\x12v\n\x0bRequestJobs\x12\x32.convergedcomputing.org.grpc.v1.RequestJobsRequest\x1a\x33.convergedcomputing.org.grpc.v1.RequestJobsResponse\x12[\n\x06Serial\x12\'.convergedcomputing.org.grpc.v1.Request\x1a(.convergedcomputing.org.grpc.v1.Response\x12_\n\x06Stream\x12\'.convergedcomputing.org.grpc.v1.Request\x1a(.convergedcomputing.org.grpc.v1.Response(\x01\x30\x01\x42\x33Z1github.com/converged-computing/rainbow/pkg/api/v1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rrainbow.proto\x12\x1e\x63onvergedcomputing.org.grpc.v1\x1a\x19google/protobuf/any.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb3\x01\n\x07\x43ontent\x12\n\n\x02id\x18\x01 \x01(\t\x12\"\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x14.google.protobuf.Any\x12G\n\x08metadata\x18\x03 \x03(\x0b\x32\x35.convergedcomputing.org.grpc.v1.Content.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"m\n\x07Request\x12\x38\n\x07\x63ontent\x18\x01 \x01(\x0b\x32\'.convergedcomputing.org.grpc.v1.Content\x12(\n\x04sent\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"Y\n\x0fRegisterRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06secret\x18\x02 \x01(\t\x12(\n\x04sent\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\x99\x01\n\x10SubmitJobRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x63luster\x18\x02 \x01(\t\x12\r\n\x05token\x18\x03 \x01(\t\x12\r\n\x05nodes\x18\x04 \x01(\x05\x12\r\n\x05tasks\x18\x05 \x01(\x05\x12\x0f\n\x07\x63ommand\x18\x06 \x01(\t\x12(\n\x04sent\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"p\n\x12RequestJobsRequest\x12\x0f\n\x07\x63luster\x18\x01 \x01(\t\x12\x0e\n\x06secret\x18\x02 \x01(\t\x12\x0f\n\x07maxJobs\x18\x03 \x01(\x05\x12(\n\x04sent\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"n\n\x11\x41\x63\x63\x65ptJobsRequest\x12\x0f\n\x07\x63luster\x18\x01 \x01(\t\x12\x0e\n\x06secret\x18\x02 \x01(\t\x12\x0e\n\x06jobids\x18\x03 \x03(\x05\x12(\n\x04sent\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\xc8\x01\n\x08Response\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\x15\n\rmessage_count\x18\x02 \x01(\x03\x12\x1a\n\x12messages_processed\x18\x03 \x01(\x03\x12\x1a\n\x12processing_details\x18\x04 \x01(\t\"Y\n\nResultType\x12\x1b\n\x17RESULT_TYPE_UNSPECIFIED\x10\x00\x12\x17\n\x13RESULT_TYPE_SUCCESS\x10\x01\x12\x15\n\x11RESULT_TYPE_ERROR\x10\x02\"\x8e\x02\n\x10RegisterResponse\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\r\n\x05token\x18\x02 \x01(\t\x12\x0e\n\x06secret\x18\x03 \x01(\t\x12K\n\x06status\x18\x04 \x01(\x0e\x32;.convergedcomputing.org.grpc.v1.RegisterResponse.ResultType\"z\n\nResultType\x12\x18\n\x14REGISTER_UNSPECIFIED\x10\x00\x12\x14\n\x10REGISTER_SUCCESS\x10\x01\x12\x12\n\x0eREGISTER_ERROR\x10\x02\x12\x13\n\x0fREGISTER_DENIED\x10\x03\x12\x13\n\x0fREGISTER_EXISTS\x10\x04\"\xe3\x01\n\x11SubmitJobResponse\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\r\n\x05jobid\x18\x02 \x01(\x05\x12L\n\x06status\x18\x03 \x01(\x0e\x32<.convergedcomputing.org.grpc.v1.SubmitJobResponse.ResultType\"]\n\nResultType\x12\x16\n\x12SUBMIT_UNSPECIFIED\x10\x00\x12\x12\n\x0eSUBMIT_SUCCESS\x10\x01\x12\x10\n\x0cSUBMIT_ERROR\x10\x02\x12\x11\n\rSUBMIT_DENIED\x10\x03\"\xe8\x02\n\x13RequestJobsResponse\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12K\n\x04jobs\x18\x02 \x03(\x0b\x32=.convergedcomputing.org.grpc.v1.RequestJobsResponse.JobsEntry\x12N\n\x06status\x18\x03 \x01(\x0e\x32>.convergedcomputing.org.grpc.v1.RequestJobsResponse.ResultType\x1a+\n\tJobsEntry\x12\x0b\n\x03key\x18\x01 \x01(\x05\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"s\n\nResultType\x12\x1a\n\x16REQUEST_JOBS_NORESULTS\x10\x00\x12\x18\n\x14REQUEST_JOBS_SUCCESS\x10\x01\x12\x16\n\x12REQUEST_JOBS_ERROR\x10\x02\x12\x17\n\x13REQUEST_JOBS_DENIED\x10\x03\"\xd7\x01\n\x12\x41\x63\x63\x65ptJobsResponse\x12M\n\x06status\x18\x01 \x01(\x0e\x32=.convergedcomputing.org.grpc.v1.AcceptJobsResponse.ResultType\"r\n\nResultType\x12\x1b\n\x17RESULT_TYPE_UNSPECIFIED\x10\x00\x12\x17\n\x13RESULT_TYPE_PARTIAL\x10\x01\x12\x17\n\x13RESULT_TYPE_SUCCESS\x10\x02\x12\x15\n\x11RESULT_TYPE_ERROR\x10\x03\x32\x9e\x05\n\x10RainbowScheduler\x12m\n\x08Register\x12/.convergedcomputing.org.grpc.v1.RegisterRequest\x1a\x30.convergedcomputing.org.grpc.v1.RegisterResponse\x12p\n\tSubmitJob\x12\x30.convergedcomputing.org.grpc.v1.SubmitJobRequest\x1a\x31.convergedcomputing.org.grpc.v1.SubmitJobResponse\x12v\n\x0bRequestJobs\x12\x32.convergedcomputing.org.grpc.v1.RequestJobsRequest\x1a\x33.convergedcomputing.org.grpc.v1.RequestJobsResponse\x12s\n\nAcceptJobs\x12\x31.convergedcomputing.org.grpc.v1.AcceptJobsRequest\x1a\x32.convergedcomputing.org.grpc.v1.AcceptJobsResponse\x12[\n\x06Serial\x12\'.convergedcomputing.org.grpc.v1.Request\x1a(.convergedcomputing.org.grpc.v1.Response\x12_\n\x06Stream\x12\'.convergedcomputing.org.grpc.v1.Request\x1a(.convergedcomputing.org.grpc.v1.Response(\x01\x30\x01\x42\x33Z1github.com/converged-computing/rainbow/pkg/api/v1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -40,24 +40,30 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_SUBMITJOBREQUEST']._serialized_end=647
   _globals['_REQUESTJOBSREQUEST']._serialized_start=649
   _globals['_REQUESTJOBSREQUEST']._serialized_end=761
-  _globals['_RESPONSE']._serialized_start=764
-  _globals['_RESPONSE']._serialized_end=964
-  _globals['_RESPONSE_RESULTTYPE']._serialized_start=875
-  _globals['_RESPONSE_RESULTTYPE']._serialized_end=964
-  _globals['_REGISTERRESPONSE']._serialized_start=967
-  _globals['_REGISTERRESPONSE']._serialized_end=1237
-  _globals['_REGISTERRESPONSE_RESULTTYPE']._serialized_start=1115
-  _globals['_REGISTERRESPONSE_RESULTTYPE']._serialized_end=1237
-  _globals['_SUBMITJOBRESPONSE']._serialized_start=1240
-  _globals['_SUBMITJOBRESPONSE']._serialized_end=1467
-  _globals['_SUBMITJOBRESPONSE_RESULTTYPE']._serialized_start=1374
-  _globals['_SUBMITJOBRESPONSE_RESULTTYPE']._serialized_end=1467
-  _globals['_REQUESTJOBSRESPONSE']._serialized_start=1470
-  _globals['_REQUESTJOBSRESPONSE']._serialized_end=1830
-  _globals['_REQUESTJOBSRESPONSE_JOBSENTRY']._serialized_start=1670
-  _globals['_REQUESTJOBSRESPONSE_JOBSENTRY']._serialized_end=1713
-  _globals['_REQUESTJOBSRESPONSE_RESULTTYPE']._serialized_start=1715
-  _globals['_REQUESTJOBSRESPONSE_RESULTTYPE']._serialized_end=1830
-  _globals['_RAINBOWSCHEDULER']._serialized_start=1833
-  _globals['_RAINBOWSCHEDULER']._serialized_end=2386
+  _globals['_ACCEPTJOBSREQUEST']._serialized_start=763
+  _globals['_ACCEPTJOBSREQUEST']._serialized_end=873
+  _globals['_RESPONSE']._serialized_start=876
+  _globals['_RESPONSE']._serialized_end=1076
+  _globals['_RESPONSE_RESULTTYPE']._serialized_start=987
+  _globals['_RESPONSE_RESULTTYPE']._serialized_end=1076
+  _globals['_REGISTERRESPONSE']._serialized_start=1079
+  _globals['_REGISTERRESPONSE']._serialized_end=1349
+  _globals['_REGISTERRESPONSE_RESULTTYPE']._serialized_start=1227
+  _globals['_REGISTERRESPONSE_RESULTTYPE']._serialized_end=1349
+  _globals['_SUBMITJOBRESPONSE']._serialized_start=1352
+  _globals['_SUBMITJOBRESPONSE']._serialized_end=1579
+  _globals['_SUBMITJOBRESPONSE_RESULTTYPE']._serialized_start=1486
+  _globals['_SUBMITJOBRESPONSE_RESULTTYPE']._serialized_end=1579
+  _globals['_REQUESTJOBSRESPONSE']._serialized_start=1582
+  _globals['_REQUESTJOBSRESPONSE']._serialized_end=1942
+  _globals['_REQUESTJOBSRESPONSE_JOBSENTRY']._serialized_start=1782
+  _globals['_REQUESTJOBSRESPONSE_JOBSENTRY']._serialized_end=1825
+  _globals['_REQUESTJOBSRESPONSE_RESULTTYPE']._serialized_start=1827
+  _globals['_REQUESTJOBSRESPONSE_RESULTTYPE']._serialized_end=1942
+  _globals['_ACCEPTJOBSRESPONSE']._serialized_start=1945
+  _globals['_ACCEPTJOBSRESPONSE']._serialized_end=2160
+  _globals['_ACCEPTJOBSRESPONSE_RESULTTYPE']._serialized_start=2046
+  _globals['_ACCEPTJOBSRESPONSE_RESULTTYPE']._serialized_end=2160
+  _globals['_RAINBOWSCHEDULER']._serialized_start=2163
+  _globals['_RAINBOWSCHEDULER']._serialized_end=2833
 # @@protoc_insertion_point(module_scope)

--- a/python/v1/rainbow/protos/rainbow_pb2.pyi
+++ b/python/v1/rainbow/protos/rainbow_pb2.pyi
@@ -4,7 +4,7 @@ from google.protobuf.internal import containers as _containers
 from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
-from typing import ClassVar as _ClassVar, Mapping as _Mapping, Optional as _Optional, Union as _Union
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
 
 DESCRIPTOR: _descriptor.FileDescriptor
 
@@ -72,6 +72,18 @@ class RequestJobsRequest(_message.Message):
     maxJobs: int
     sent: _timestamp_pb2.Timestamp
     def __init__(self, cluster: _Optional[str] = ..., secret: _Optional[str] = ..., maxJobs: _Optional[int] = ..., sent: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ...) -> None: ...
+
+class AcceptJobsRequest(_message.Message):
+    __slots__ = ("cluster", "secret", "jobids", "sent")
+    CLUSTER_FIELD_NUMBER: _ClassVar[int]
+    SECRET_FIELD_NUMBER: _ClassVar[int]
+    JOBIDS_FIELD_NUMBER: _ClassVar[int]
+    SENT_FIELD_NUMBER: _ClassVar[int]
+    cluster: str
+    secret: str
+    jobids: _containers.RepeatedScalarFieldContainer[int]
+    sent: _timestamp_pb2.Timestamp
+    def __init__(self, cluster: _Optional[str] = ..., secret: _Optional[str] = ..., jobids: _Optional[_Iterable[int]] = ..., sent: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ...) -> None: ...
 
 class Response(_message.Message):
     __slots__ = ("request_id", "message_count", "messages_processed", "processing_details")
@@ -163,3 +175,19 @@ class RequestJobsResponse(_message.Message):
     jobs: _containers.ScalarMap[int, str]
     status: RequestJobsResponse.ResultType
     def __init__(self, request_id: _Optional[str] = ..., jobs: _Optional[_Mapping[int, str]] = ..., status: _Optional[_Union[RequestJobsResponse.ResultType, str]] = ...) -> None: ...
+
+class AcceptJobsResponse(_message.Message):
+    __slots__ = ("status",)
+    class ResultType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        RESULT_TYPE_UNSPECIFIED: _ClassVar[AcceptJobsResponse.ResultType]
+        RESULT_TYPE_PARTIAL: _ClassVar[AcceptJobsResponse.ResultType]
+        RESULT_TYPE_SUCCESS: _ClassVar[AcceptJobsResponse.ResultType]
+        RESULT_TYPE_ERROR: _ClassVar[AcceptJobsResponse.ResultType]
+    RESULT_TYPE_UNSPECIFIED: AcceptJobsResponse.ResultType
+    RESULT_TYPE_PARTIAL: AcceptJobsResponse.ResultType
+    RESULT_TYPE_SUCCESS: AcceptJobsResponse.ResultType
+    RESULT_TYPE_ERROR: AcceptJobsResponse.ResultType
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    status: AcceptJobsResponse.ResultType
+    def __init__(self, status: _Optional[_Union[AcceptJobsResponse.ResultType, str]] = ...) -> None: ...

--- a/python/v1/rainbow/protos/rainbow_pb2_grpc.py
+++ b/python/v1/rainbow/protos/rainbow_pb2_grpc.py
@@ -30,6 +30,11 @@ class RainbowSchedulerStub(object):
                 request_serializer=rainbow__pb2.RequestJobsRequest.SerializeToString,
                 response_deserializer=rainbow__pb2.RequestJobsResponse.FromString,
                 )
+        self.AcceptJobs = channel.unary_unary(
+                '/convergedcomputing.org.grpc.v1.RainbowScheduler/AcceptJobs',
+                request_serializer=rainbow__pb2.AcceptJobsRequest.SerializeToString,
+                response_deserializer=rainbow__pb2.AcceptJobsResponse.FromString,
+                )
         self.Serial = channel.unary_unary(
                 '/convergedcomputing.org.grpc.v1.RainbowScheduler/Serial',
                 request_serializer=rainbow__pb2.Request.SerializeToString,
@@ -62,6 +67,13 @@ class RainbowSchedulerServicer(object):
 
     def RequestJobs(self, request, context):
         """Request Job - ask the rainbow scheduler for up to max jobs
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def AcceptJobs(self, request, context):
+        """Accept Jobs - accept some number of jobs
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -100,6 +112,11 @@ def add_RainbowSchedulerServicer_to_server(servicer, server):
                     servicer.RequestJobs,
                     request_deserializer=rainbow__pb2.RequestJobsRequest.FromString,
                     response_serializer=rainbow__pb2.RequestJobsResponse.SerializeToString,
+            ),
+            'AcceptJobs': grpc.unary_unary_rpc_method_handler(
+                    servicer.AcceptJobs,
+                    request_deserializer=rainbow__pb2.AcceptJobsRequest.FromString,
+                    response_serializer=rainbow__pb2.AcceptJobsResponse.SerializeToString,
             ),
             'Serial': grpc.unary_unary_rpc_method_handler(
                     servicer.Serial,
@@ -170,6 +187,23 @@ class RainbowScheduler(object):
         return grpc.experimental.unary_unary(request, target, '/convergedcomputing.org.grpc.v1.RainbowScheduler/RequestJobs',
             rainbow__pb2.RequestJobsRequest.SerializeToString,
             rainbow__pb2.RequestJobsResponse.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def AcceptJobs(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/convergedcomputing.org.grpc.v1.RainbowScheduler/AcceptJobs',
+            rainbow__pb2.AcceptJobsRequest.SerializeToString,
+            rainbow__pb2.AcceptJobsResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 

--- a/python/v1/setup.py
+++ b/python/v1/setup.py
@@ -18,7 +18,7 @@ except Exception:
 if __name__ == "__main__":
     setup(
         name="rainbow-scheduler",
-        version="0.0.0",
+        version="0.0.1",
         author="Vanessasaurus",
         author_email="vsoch@users.noreply.github.com",
         maintainer="Vanessasaurus",


### PR DESCRIPTION
After this is added, we have the basic logic to be able to submit, and then query for and accept some number of jobs. We can next build containers and prototype this with actual flux instances... somewhere.