### PR TITLE
add Dockerfile and automated builds

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -1,0 +1,76 @@
+name: rainbow build-and deploy
+
+on:
+  pull_request: []
+  release:
+    types: [published]
+  push:
+    branches:
+    - main
+
+# Note that:
+# rainbow:flux is the same, but has flux (and considered a client container)
+# rainbow:latest doesn't have flux (for the scheduler)
+# both have the rainbow / rainbow-scheduler build, it's just one has flux ;)
+jobs:
+  build-rainbow:
+    permissions:
+      packages: write
+    env:
+      container: ghcr.io/converged-computing/rainbow-flux
+    runs-on: ubuntu-latest
+    name: build rainbow (client)
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build Containers
+      run: make docker-flux
+
+    - name: Tag Release Image
+      if: (github.event_name == 'release')
+      run: |
+        tag=${GITHUB_REF#refs/tags/}
+        echo "Tagging and releasing ${{ env.container}}:${tag}"        
+        docker tag ${{ env.container }}:latest ${{ env.container }}:${tag}
+
+    - name: GHCR Login
+      if: (github.event_name != 'pull_request')
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Deploy Container
+      if: (github.event_name != 'pull_request')
+      run: docker push ${{ env.container }} --all-tags
+      
+  build-rainbow-scheduler:
+    permissions:
+      packages: write
+    env:
+      container: ghcr.io/converged-computing/rainbow-scheduler
+    runs-on: ubuntu-latest
+    name: build rainbow (scheduler)
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build Containers
+      run: make docker-ubuntu
+
+    - name: Tag Release Image
+      if: (github.event_name == 'release')
+      run: |
+        tag=${GITHUB_REF#refs/tags/}
+        echo "Tagging and releasing ${{ env.container}}:${tag}"        
+        docker tag ${{ env.container }}:latest ${{ env.container }}:${tag}
+
+    - name: GHCR Login
+      if: (github.event_name != 'pull_request')
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Deploy Container
+      if: (github.event_name != 'pull_request')
+      run: docker push ${{ env.container }} --all-tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+ARG base="ubuntu:jammy"
+FROM $base
+USER root
+LABEL MAINTAINER Author <vsoch>
+
+# install go 20.10
+RUN apt-get update && apt-get install -y wget python3-pip
+RUN wget https://go.dev/dl/go1.20.10.linux-amd64.tar.gz  && tar -xvf go1.20.10.linux-amd64.tar.gz && \
+         mv go /usr/local && rm go1.20.10.linux-amd64.tar.gz
+
+ENV PATH=/usr/local/go/bin:$PATH
+WORKDIR /code
+COPY . /code
+RUN make build && \
+    cp ./bin/rainbow /usr/bin && \
+    cp ./bin/rainbow-scheduler /usr/local/bin
+
+# ensure we install the python bindings
+RUN cd /code/python/v1 && \
+    python3 -m pip install .
+
+ENTRYPOINT ["rainbow-scheduler"]
+
+# Anticipate different running contexts
+EXPOSE 80
+EXPOSE 8080
+EXPOSE 443
+
+# Recommended to add --secret here! If you need to persist the database, mount that
+# or we can add support for non sqlite.
+CMD ["--address", "0.0.0.0:8080", "--name", "rainbow"]

--- a/README.md
+++ b/README.md
@@ -203,7 +203,29 @@ What this does is randomly select from the set you receive, and send back a resp
 The logic you would expect is there - that you can't accept greater than the number available.
 You could try asking for a high level of max jobs again, and see that there is one fewer than before. It was deleted from the database.
 
-## Python
+## Development
+
+### Build
+
+You can build the binaries:
+
+```console
+$ make build
+mkdir -p /home/vanessa/Desktop/Code/rainbow/bin
+GO111MODULE="on" go build -o /home/vanessa/Desktop/Code/rainbow/bin/rainbow cmd/rainbow/rainbow.go
+GO111MODULE="on" go build -o /home/vanessa/Desktop/Code/rainbow/bin/rainbow-scheduler cmd/server/server.go
+```
+
+Note that the `rainbow-scheduler` starts the server, and `rainbow` is the set of client commands.
+
+```console
+$ ls bin/
+protoc-gen-go  protoc-gen-go-grpc  rainbow  rainbow-scheduler
+```
+
+They are placed in the local bin, as shown above.
+
+### Python
 
 To build Python GRPC, ensure you have the grpc-tools installed:
 
@@ -222,7 +244,29 @@ and cd into [python/v1](python/v1) and follow the README instructions there.
 
 ## Container Images
 
-**Coming soon**
+We provide make commands to build:
+
+- **ghcr.io/converged-computing/rainbow-scheduler**: the scheduler (the `rainbow` client and `rainbow-scheduler` binaries in an ubuntu base, intended to be run as the scheduler image)
+- **ghcr.io/converged-computing/rainbow-flux**: the client (includes flux) for interacting with a scheduler.
+
+Both images above have both binaries, it's just that the second has flux added. We can add more schedulers or other entities that can
+accept jobs as needed. You can build in any of the following ways:
+
+```bash
+# both images, default registry
+make docker
+
+# scheduler
+make docker-ubuntu
+
+# client with flux
+make docker-flux
+
+# customize the registry for any command above
+REGISTRY=vanessa make docker
+```
+
+Further instructions will be added for running these containers in the next round of work - likely we will have a basic kind setup that demonstrates the orchestration.
 
 ## TODO
 


### PR DESCRIPTION
we are building two containers - one with just the scheduler (ubuntu base) and one intended to be run as a client (with flux added). Arguably any thing that can accept jobs can be a client, but we are starting with flux