### PR TITLE
feat: support to convert from artifact to jobspec

### DIFF
--- a/python/v1/rainbow/jobspec/converter.py
+++ b/python/v1/rainbow/jobspec/converter.py
@@ -1,6 +1,52 @@
 import shlex
 
 
+def from_compatibility_spec(
+    compspec, command, nodes, name=None, tasks=1, jobspec_version=1, attributes=None
+):
+    """
+    Generate a jobspec from a compatibility spec.
+    """
+    # Start with a basic one we will modify
+    js = new_simple_jobspec(command, nodes, name, tasks, jobspec_version)
+
+    # This is an optional lookup that can filter down to attributes of interest
+    attributes = attributes or {}
+
+    # The first task is lammps
+    task = js["tasks"][0]
+
+    # Generate task resources based on compatibility metadata
+    # Note that each of these has associated graphs we aren't using
+    resources = {}
+    for compat in compspec.get("compatibilities", []):
+        # Treat these flat for now. E.g., io.archspec instead of io -> archspec
+        resource_set = {}
+
+        # Here we are creating a set of attributes for a subsystem.
+        # E.g., "For io.archpsec I care about cpu.target"
+        name = compat.get("name")
+
+        # Skip those we don't care about for the level
+        if not name or (attributes and name not in attributes):
+            continue
+
+        for attrname, attrvalue in compat.get("attributes", {}).items():
+            if attributes and attrname not in attributes[name]:
+                continue
+            resource_set[attrname] = attrvalue
+
+        # Only add resource sets with at least one attribute
+        if resource_set:
+            resources[compat["name"]] = resource_set
+
+    if resources:
+        task["resources"] = resources
+
+    js["tasks"][0] = task
+    return js
+
+
 def new_simple_jobspec(command, nodes=1, name=None, tasks=1, jobspec_version=1):
     """
     Generate a new simple jobspec from basic parameters.

--- a/python/v1/setup.py
+++ b/python/v1/setup.py
@@ -18,7 +18,7 @@ except Exception:
 if __name__ == "__main__":
     setup(
         name="rainbow-scheduler",
-        version="0.0.12",
+        version="0.0.13",
         author="Vanessasaurus",
         author_email="vsoch@users.noreply.github.com",
         maintainer="Vanessasaurus",


### PR DESCRIPTION
Problem: we want to be able to convert a compatibility artifact to a jobspec.
Solution: provide this function with rainbow, just the Python module for now (that we will use for experiments). I will post more detail in descriptive slack.