### PR TITLE
bug: matches not accounted for with go client

### DIFF
--- a/docs/examples/memgraph/rainbow-config.yaml
+++ b/docs/examples/memgraph/rainbow-config.yaml
@@ -8,7 +8,7 @@ scheduler:
             name: match
 cluster:
     name: keebler
-    secret: 162c041b-db57-444b-917c-a5528bd4e6ff
+    secret: a38e8008-c5ef-4803-821f-4c930d366a3c
 graphdatabase:
     name: memgraph
     host: 127.0.0.1:50051

--- a/docs/examples/scheduler/rainbow-config.yaml
+++ b/docs/examples/scheduler/rainbow-config.yaml
@@ -8,7 +8,7 @@ scheduler:
             name: match
 cluster:
     name: keebler
-    secret: e8f9ff3b-80be-4d5e-8e71-2564f08602cf
+    secret: 27933478-5c96-4473-bd47-b829b5d0eaf9
 graphdatabase:
     name: memory
     host: 127.0.0.1:50051

--- a/pkg/client/endpoint.go
+++ b/pkg/client/endpoint.go
@@ -77,8 +77,14 @@ func (c *RainbowClient) SubmitJob(
 
 	// Prepare clusters for submit jobs request
 	clusters := make([]*pb.SubmitJobRequest_Cluster, len(cfg.Clusters))
-	for i, cluster := range cfg.Clusters {
-		clusters[i] = &pb.SubmitJobRequest_Cluster{Token: cluster.Token, Name: cluster.Name}
+
+	// Take an intersection of clusters and matches
+	// A token will not be returned if we do not know about the cluster
+	for i, match := range matches {
+		creds := cfg.GetClusterToken(match)
+		if creds != "" {
+			clusters[i] = &pb.SubmitJobRequest_Cluster{Token: creds, Name: match}
+		}
 	}
 
 	// Jobspec gets converted back to string for easier serialization

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,6 +103,16 @@ func (c *RainbowConfig) ToJson() (string, error) {
 	return string(out), nil
 }
 
+// GetCluster returns a cluster, if it is known to the config
+func (c *RainbowConfig) GetClusterToken(clusterName string) string {
+	for _, c := range c.Clusters {
+		if c.Name == clusterName {
+			return c.Token
+		}
+	}
+	return ""
+}
+
 // AddCluster adds a cluster on the fly to a config, likely for a one-off submit
 func (c *RainbowConfig) AddCluster(clusterName, token string) error {
 

--- a/plugins/backends/memgraph/memgraph.go
+++ b/plugins/backends/memgraph/memgraph.go
@@ -319,6 +319,7 @@ func (g Memgraph) Satisfies(
 ) ([]string, error) {
 
 	matches := []string{}
+	// query, err := matcher.GenerateCypher(jobspec)
 
 	// Prepare query that looks for slots
 	// The slot STARTS at the first resource type and stops right after the slot


### PR DESCRIPTION
Problem: we needed to take the intersection of the matches and clusters known to the user config as
the final set to return. Currently we are just providing all the clusters in the user config,
regardless of match.

Solution: create a function to retrieve the token for a named cluster, which only returns the token if it is known. This is akin to taking an intersection between the matches and clusters known.