### PR TITLE
grabdb init: ensure that error returned is checked

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -85,7 +85,10 @@ func NewServer(
 	}
 
 	// Run init with any options from the config, and the match algorithm
-	graphDB.Init(cfg.GraphDatabase.Options)
+	err = graphDB.Init(cfg.GraphDatabase.Options)
+	if err != nil {
+		log.Fatal(err)
+	}
 	log.Printf("🧩️ graph database: %v", graphDB.Name())
 
 	// init the database, creating jobs and clusters tables


### PR DESCRIPTION
Problem: calling the graphdb.Init returns an error but we are not checking it.
Solution: check it